### PR TITLE
fix: after query callback error

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -19,6 +19,10 @@ const (
 type UpdateDiff map[string]interface{}
 
 func (p *Plugin) trackEntity(scope *gorm.Scope) {
+	if !isLoggable(scope.Value) || !isEnabled(scope.Value) {
+		return
+	}
+
 	v := reflect.Indirect(reflect.ValueOf(scope.Value))
 
 	pkName := scope.PrimaryField().Name


### PR DESCRIPTION
```
if _, err := loggable.Register(db, loggable.ComputeDiff()); err != nil {
	panic(err)
}
```

Bug Reproduce 
```
tx.Raw("SELECT nextval('case_number_seq')").Take(&result)
```

error logs
```
runtime error: invalid memory address or nil pointer dereference
/usr/local/Cellar/go/1.11.4/libexec/src/runtime/panic.go:513 (0x102c308)
	gopanic: reflectcall(nil, unsafe.Pointer(d.fn), deferArgs(d), uint32(d.siz), uint32(d.siz))
/Users/wu.dev/go/pkg/mod/github.com/jinzhu/gorm@v1.9.2/scope.go:863 (0x1367812)
	(*Scope).callCallbacks.func1: panic(err)
/usr/local/Cellar/go/1.11.4/libexec/src/runtime/asm_amd64.s:522 (0x1057b9a)
	call32: CALLFN(·call32, 32)
/usr/local/Cellar/go/1.11.4/libexec/src/runtime/panic.go:513 (0x102c308)
	gopanic: reflectcall(nil, unsafe.Pointer(d.fn), deferArgs(d), uint32(d.siz), uint32(d.siz))
/Users/wu.dev/go/pkg/mod/github.com/jinzhu/gorm@v1.9.2/scope.go:863 (0x1367812)
	(*Scope).callCallbacks.func1: panic(err)
/usr/local/Cellar/go/1.11.4/libexec/src/runtime/asm_amd64.s:522 (0x1057b9a)
	call32: CALLFN(·call32, 32)
/usr/local/Cellar/go/1.11.4/libexec/src/runtime/panic.go:513 (0x102c308)
	gopanic: reflectcall(nil, unsafe.Pointer(d.fn), deferArgs(d), uint32(d.siz), uint32(d.siz))
/usr/local/Cellar/go/1.11.4/libexec/src/runtime/panic.go:82 (0x102b45d)
	panicmem: panic(memoryError)
/usr/local/Cellar/go/1.11.4/libexec/src/runtime/signal_unix.go:390 (0x1041b21)
	sigpanic: panicmem()
/Users/wu.dev/go/pkg/mod/github.com/sas1024/gorm-loggable@v0.0.0-20190214071456-531c4d37e905/callbacks.go:24 (0x15e9b51)
	(*Plugin).trackEntity: pkName := scope.PrimaryField().Name
/Users/wu.dev/go/pkg/mod/github.com/sas1024/gorm-loggable@v0.0.0-20190214071456-531c4d37e905/plugin.go:23 (0x15ed973)
	(*Plugin).trackEntity-fm: callback.Query().After("gorm:after_query").Register("loggable:query", p.trackEntity)
/Users/wu.dev/go/pkg/mod/github.com/jinzhu/gorm@v1.9.2/scope.go:867 (0x1353727)
	(*Scope).callCallbacks: (*f)(scope)
/Users/wu.dev/go/pkg/mod/github.com/jinzhu/gorm@v1.9.2/main.go:301 (0x1341d41)
	(*DB).Take: return newScope.inlineCondition(where...).callCallbacks(s.parent.callbacks.queries).db
/Users/wu.dev/go/src/github.com/castlery/Casehub/apiserver/model/case.go:64 (0x17be3a6)
	(*Case).AfterCreate: if err := tx.Raw("SELECT nextval('case_number_seq')").Take(&result).Error; err != nil {
/usr/local/Cellar/go/1.11.4/libexec/src/runtime/asm_amd64.s:522 (0x1057b9a)
	call32: CALLFN(·call32, 32)
/usr/local/Cellar/go/1.11.4/libexec/src/reflect/value.go:689 (0x10b419f)
	callMethod: call(frametype, fn, scratch, uint32(frametype.size), uint32(retOffset))
/usr/local/Cellar/go/1.11.4/libexec/src/reflect/asm_amd64.s:35 (0x10bd731)
	methodValueCall: CALL	·callMethod(SB)
/Users/wu.dev/go/pkg/mod/github.com/jinzhu/gorm@v1.9.2/scope.go:454 (0x134d3b5)
	(*Scope).callMethod: scope.Err(method(newDB))
/Users/wu.dev/go/pkg/mod/github.com/jinzhu/gorm@v1.9.2/scope.go:252 (0x134b8b1)
	(*Scope).CallMethod: scope.callMethod(methodName, indirectScopeValue)
/Users/wu.dev/go/pkg/mod/github.com/jinzhu/gorm@v1.9.2/callback_create.go:159 (0x132a77f)
	afterCreateCallback: scope.CallMethod("AfterCreate")
/Users/wu.dev/go/pkg/mod/github.com/jinzhu/gorm@v1.9.2/scope.go:867 (0x1353727)
	(*Scope).callCallbacks: (*f)(scope)

```