### PR TITLE
Hide disabled attribute at json export

### DIFF
--- a/loggable.go
+++ b/loggable.go
@@ -25,7 +25,7 @@ type Interface interface {
 // LoggableModel is a root structure, which implement Interface.
 // Embed LoggableModel to your model so that Plugin starts tracking changes.
 type LoggableModel struct {
-	Disabled bool `sql:"-"`
+	Disabled bool `sql:"-" json:"-"`
 }
 
 func (LoggableModel) Meta() interface{} { return nil }


### PR DESCRIPTION
We have the problem that we deliver models via JSON API. Where currently always capitalized `Disabled` stands, what we would have to filter out again now.